### PR TITLE
feat: assets for Manasteal at CharacterWindow.json

### DIFF
--- a/resources/gui/layouts/game/CharacterWindow.json
+++ b/resources/gui/layouts/game/CharacterWindow.json
@@ -1171,6 +1171,36 @@
         "AutoSizeToContents": true,
         "Font": "sourcesansproblack,8",
         "TextScale": 1.0
+      },
+      "Manasteal": {
+        "Bounds": "225,164,1,14",
+        "Padding": "0,0,0,0",
+        "AlignmentEdgeDistances": "0,0,0,0",
+        "AlignmentTransform": "0,0",
+        "Margin": "0,0,0,0",
+        "RenderColor": "255,255,255,255",
+        "Alignments": "",
+        "DrawBackground": true,
+        "MinimumSize": "1,1",
+        "MaximumSize": "4096,4096",
+        "Disabled": false,
+        "Hidden": false,
+        "RestrictToParent": false,
+        "MouseInputEnabled": false,
+        "HideToolTip": false,
+        "ToolTipBackground": null,
+        "ToolTipFont": null,
+        "ToolTipTextColor": "",
+        "BackgroundTemplate": null,
+        "TextColor": "255,255,255,255",
+        "HoveredTextColor": "",
+        "ClickedTextColor": "",
+        "DisabledTextColor": "255,90,90,90",
+        "TextAlign": "Left, Top",
+        "TextPadding": "0,0,0,0",
+        "AutoSizeToContents": true,
+        "Font": "sourcesansproblack,8",
+        "TextScale": 1.0
       }
     }
   }


### PR DESCRIPTION
Required assets for _Manasteal_ buff information at Character's window.

Preview:

![image](https://user-images.githubusercontent.com/17498701/197278011-4afaaef4-32c2-497f-a7e2-6b4b26f582cd.png)
