### PR TITLE
asset enhancement: context menus

### DIFF
--- a/resources/gui/layouts/game/BagContextMenu.json
+++ b/resources/gui/layouts/game/BagContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }

--- a/resources/gui/layouts/game/BankContextMenu.json
+++ b/resources/gui/layouts/game/BankContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }

--- a/resources/gui/layouts/game/ChatContextMenu.json
+++ b/resources/gui/layouts/game/ChatContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }

--- a/resources/gui/layouts/game/ChatboxWindow.json
+++ b/resources/gui/layouts/game/ChatboxWindow.json
@@ -989,8 +989,8 @@
           }
         },
         "BackgroundTemplate": "dropdownbg.png",
-        "ItemTextColor": "255,200,200,200",
-        "ItemHoveredTextColor": "255,240,240,240",
+        "ItemTextColor": "255,112,112,112",
+        "ItemHoveredTextColor": "255,255,255,255",
         "ItemFont": "sourcesansproblack,10"
       },
       "DropDownButton": {

--- a/resources/gui/layouts/game/GuildContextMenu.json
+++ b/resources/gui/layouts/game/GuildContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }

--- a/resources/gui/layouts/game/InventoryContextMenu.json
+++ b/resources/gui/layouts/game/InventoryContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }

--- a/resources/gui/layouts/game/ShopContextMenu.json
+++ b/resources/gui/layouts/game/ShopContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }

--- a/resources/gui/layouts/game/SpellContextMenu.json
+++ b/resources/gui/layouts/game/SpellContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }

--- a/resources/gui/layouts/game/TradeContextMenu.json
+++ b/resources/gui/layouts/game/TradeContextMenu.json
@@ -289,7 +289,7 @@
     }
   },
   "BackgroundTemplate": "contextmenu.png",
-  "ItemTextColor": "255,255,255,255",
-  "ItemHoveredTextColor": "255,128,128,128",
+  "ItemTextColor": "255,112,112,112",
+  "ItemHoveredTextColor": "255,255,255,255",
   "ItemFont": "sourcesansproblack,10"
 }


### PR DESCRIPTION
* grays down non-hovered context menu items.
* highlights hovered menu items into full white color.
* applies the corresponding changes to context menus at: 
             bags, bank, chat, chatbox, guild, inventory, shop, spell and trade windows

Before this enhancement:

https://user-images.githubusercontent.com/17498701/200020743-b41d0fbe-7638-4f59-88d4-8628fe111ba9.mp4


After this enhancement:

https://user-images.githubusercontent.com/17498701/200020358-35d42304-be6e-4322-8db7-f55e2f8c6f95.mp4

