### PR TITLE
enhancement: craft window ingredients

### DIFF
--- a/resources/gui/layouts/game/CraftingIngredient.json
+++ b/resources/gui/layouts/game/CraftingIngredient.json
@@ -1,9 +1,9 @@
 {
-  "Bounds": "0,0,34,35",
+  "Bounds": "0,0,34,34",
   "Padding": "0,0,0,0",
   "AlignmentEdgeDistances": "0,0,0,0",
   "AlignmentTransform": "0,0",
-  "Margin": "4,4,4,4",
+  "Margin": "7,7,7,7",
   "RenderColor": "255,255,255,255",
   "Alignments": "",
   "DrawBackground": true,

--- a/resources/gui/layouts/game/CraftingWindow.json
+++ b/resources/gui/layouts/game/CraftingWindow.json
@@ -139,7 +139,7 @@
     "ToolTipTextColor": "",
     "Children": {
       "IngredientsContainer": {
-        "Bounds": "210,142,220,242",
+        "Bounds": "210,143,220,241",
         "Padding": "0,0,0,0",
         "AlignmentEdgeDistances": "0,0,0,0",
         "AlignmentTransform": "0,0",
@@ -159,7 +159,7 @@
         "ToolTipTextColor": "",
         "CanScrollH": false,
         "CanScrollV": true,
-        "AutoHideBars": false,
+        "AutoHideBars": true,
         "InnerPanel": {
           "Bounds": "0,0,10,10",
           "Padding": "0,0,0,0",


### PR DESCRIPTION
Minor QoL improvements such as:
* Changed a little pixel for IngredientsContainer Bounds.
* Enabled AutoHideBars: only display scroll bar when the ingredients list is too long !
* Changed size and margin dimensions of ingredients that are listed per craft so we can sort them in their list in a more easy to view way that's organized with 4 ingredients per row.

Before:

![imagen](https://user-images.githubusercontent.com/17498701/221050100-f54918cb-e908-442b-9f14-710d6f40986a.png)   ![imagen](https://user-images.githubusercontent.com/17498701/221050031-899644b2-a46b-4eaf-be57-81a1944cc1ea.png)


After:

![imagen](https://user-images.githubusercontent.com/17498701/221051044-07dcbd8d-0852-4741-91e1-9504baca9d9d.png)   ![imagen](https://user-images.githubusercontent.com/17498701/221051109-16cc6276-6838-4b97-8ea0-6c9a6d988ac3.png) 

https://user-images.githubusercontent.com/17498701/221050545-cc2bd406-350e-4b9d-a408-287fa5222a52.mp4


